### PR TITLE
Support more selection variables

### DIFF
--- a/src/core/exact_m5ig_encoder.hpp
+++ b/src/core/exact_m5ig_encoder.hpp
@@ -632,7 +632,29 @@ namespace also
         }
         else if( g != h && g == 0 ) /* a_const */
         {
-          input_set_map = comput_input_and_set_map( a_const );
+          if( is_element_duplicate( array ) )
+          {
+            if( h == j )
+            {
+              input_set_map = comput_input_and_set_map( a_const_bc_equal );
+            }
+            else if( j == k )
+            {
+              input_set_map = comput_input_and_set_map( a_const_cd_equal );
+            }
+            else if( k == l )
+            {
+              input_set_map = comput_input_and_set_map( a_const_de_equal );
+            }
+            else
+            {
+              assert( false );
+            }
+          }
+          else
+          {
+            input_set_map = comput_input_and_set_map( a_const );
+          }
         }
         else if( g == h && g == 0) /* ab_const */
         {

--- a/src/core/exact_m5ig_encoder.hpp
+++ b/src/core/exact_m5ig_encoder.hpp
@@ -584,7 +584,6 @@ namespace also
       bool is_element_duplicate( const std::vector<unsigned>& array )
       {
         auto copy = array;
-        copy.erase( copy.begin() ); //remove the first element that indicates step index
         auto last = std::unique( copy.begin(), copy.end() );
 
         return ( last == copy.end() ) ? false : true;
@@ -1024,31 +1023,31 @@ namespace also
 
             if( g == h && g != 0)
             {
-              for( const auto op_idx : ops_ab_compl )
+              for( const auto& op_idx : ops_ab_compl )
               {
                 pLits[1] = pabc::Abc_Var2Lit( get_op_var( spec, step_idx, op_idx ), 1 );
                 ret &= solver->add_clause(pLits, pLits + 2);
               }
             }
-            else if( h == j && h != 0 )
+            else if( h == j )
             {
-              for( const auto op_idx : ops_bc_compl )
+              for( const auto& op_idx : ops_bc_compl )
               {
                 pLits[1] = pabc::Abc_Var2Lit( get_op_var( spec, step_idx, op_idx ), 1 );
                 ret &= solver->add_clause(pLits, pLits + 2);
               }
             }
-            else if( j == k && j != 0 )
+            else if( j == k )
             {
-              for( const auto op_idx : ops_cd_compl )
+              for( const auto& op_idx : ops_cd_compl )
               {
                 pLits[1] = pabc::Abc_Var2Lit( get_op_var( spec, step_idx, op_idx ), 1 );
                 ret &= solver->add_clause(pLits, pLits + 2);
               }
             }
-            else if( k == l && k != 0 )
+            else if( k == l )
             {
-              for( const auto op_idx : ops_de_compl )
+              for( const auto& op_idx : ops_de_compl )
               {
                 pLits[1] = pabc::Abc_Var2Lit( get_op_var( spec, step_idx, op_idx ), 1 );
                 ret &= solver->add_clause(pLits, pLits + 2);
@@ -1056,7 +1055,14 @@ namespace also
             }
             else
             {
-              assert( false ); //cannot happen
+              if( g == h && g == 0 )
+              { 
+                continue;
+              }
+              else
+              {
+                assert( false ); //cannot happen
+              }
             }
           }
         }

--- a/src/core/m5ig_helper.hpp
+++ b/src/core/m5ig_helper.hpp
@@ -29,7 +29,11 @@ namespace also
     ab_equal,
     bc_equal,
     cd_equal,
-    de_equal
+    de_equal,
+
+    a_const_bc_equal,
+    a_const_cd_equal,
+    a_const_de_equal
   };
 
   /******************************************************************************
@@ -348,21 +352,21 @@ namespace also
 
           case a_const:
             {
-              kitty::create_from_hex_string( a, "00000000");
+              kitty::clear( a );
             }
             break;
 
           case ab_const:
             {
-              kitty::create_from_hex_string( a, "00000000");
-              kitty::create_from_hex_string( b, "00000000");
+              kitty::clear( a );
+              kitty::clear( b );
             }
             break;
 
           case ab_const_cd_equal:
             {
-              kitty::create_from_hex_string( a, "00000000");
-              kitty::create_from_hex_string( b, "00000000");
+              kitty::clear( a );
+              kitty::clear( b );
               kitty::create_nth_var( d, 2 );
             }
             break;
@@ -391,6 +395,27 @@ namespace also
             }
             break;
 
+          case a_const_bc_equal:
+            {
+              kitty::clear( a );
+              kitty::create_nth_var( c, 1 );
+            }
+            break;
+
+          case a_const_cd_equal:
+            {
+              kitty::clear( a );
+              kitty::create_nth_var( d, 2 );
+            }
+            break;
+          
+          case a_const_de_equal:
+            {
+              kitty::clear( a );
+              kitty::create_nth_var( e, 3 );
+            }
+            break;
+          
           default:
             break;
         }
@@ -557,6 +582,9 @@ namespace also
         {
           //ab_equal
           count += get_all_combination_index( idx_array, idx_array.size(), 4u ).size() * 4;
+
+          //0aabc, ..., 0cdee
+          count += get_all_combination_index( idx_array, idx_array.size(), 3u ).size() * 3;
         }
         return count;
       }
@@ -633,6 +661,7 @@ namespace also
           //ab_equal
           if( allow_two_equal )
           {
+            /* aabcd, ... bcdee */
             for( const auto c : get_all_combination_index( idx_array, idx_array.size(), 4u ) )
             {
               for( auto k = 0; k < 4; k++ )
@@ -640,6 +669,20 @@ namespace also
                 auto copy = c;
                 auto val = copy[k];
                 copy.insert( copy.begin() + k, val );
+                copy.insert( copy.begin(), i);
+                map.insert( std::pair<int, std::vector<unsigned>>( count++, copy ) );
+              }
+            }
+            
+            /* 0aabc, ... 0cdee */
+            for( const auto c : get_all_combination_index( idx_array, idx_array.size(), 3u ) )
+            {
+              for( auto k = 0; k < 3; k++ )
+              {
+                auto copy = c;
+                auto val = copy[k];
+                copy.insert( copy.begin() + k, val );
+                copy.insert( copy.begin(), 0);
                 copy.insert( copy.begin(), i);
                 map.insert( std::pair<int, std::vector<unsigned>>( count++, copy ) );
               }
@@ -773,6 +816,9 @@ namespace also
         {
           //ab_equal
           count += get_all_combination_index( idx_array, idx_array.size(), 4u ).size() * 4;
+
+          //0aabc, ..., 0cdee
+          count += get_all_combination_index( idx_array, idx_array.size(), 3u ).size() * 3;
         }
         return count;
       }
@@ -854,6 +900,7 @@ namespace also
           //ab_equal
           if( allow_two_equal )
           {
+            /* aabcd, ... bcdee */
             for( const auto c : get_all_combination_index( idx_array, idx_array.size(), 4u ) )
             {
               for( auto k = 0; k < 4; k++ )
@@ -861,6 +908,20 @@ namespace also
                 auto copy = c;
                 auto val = copy[k];
                 copy.insert( copy.begin() + k, val );
+                copy.insert( copy.begin(), i);
+                map.insert( std::pair<int, std::vector<unsigned>>( count++, copy ) );
+              }
+            }
+            
+            /* 0aabc, ... 0cdee */
+            for( const auto c : get_all_combination_index( idx_array, idx_array.size(), 3u ) )
+            {
+              for( auto k = 0; k < 3; k++ )
+              {
+                auto copy = c;
+                auto val = copy[k];
+                copy.insert( copy.begin() + k, val );
+                copy.insert( copy.begin(), 0);
                 copy.insert( copy.begin(), i);
                 map.insert( std::pair<int, std::vector<unsigned>>( count++, copy ) );
               }


### PR DESCRIPTION
Now support more selection variables such as <0aabc>, <0abbc>,....,<0cdee>

Also, for the duplicated inputs, we do not allow they appeared as complemented polarities.
For example, <a!abcd>, is actually reduced to <bcd> since variable a does not has impact on the output.

In total, the strategies make the solver faster and using a fewer number of nodes.